### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ npm run serve
 ## Running Unit (Jest) Tests
 
 ```
-$ npm t
+$ npm test
 ```
 
 ## Running End-to-end tests


### PR DESCRIPTION
`npm t`  ->  `npm test`